### PR TITLE
Fixed typos

### DIFF
--- a/docs/before-contributing.rst
+++ b/docs/before-contributing.rst
@@ -40,7 +40,7 @@ All code contributions should make every effort to match Manalyze's coding style
     * Use lowercase for function names, function members and local variables. Separate words with underscores (i.e. ``void process_int(int i);``).
     * Use capital letters for global variables and program-wide contants, and underscores to separate words (i.e. ``#define NUMBER_OF_TRIES 10``).
     * Prefix private class method and member names with an underscore (i.e ``private: std::string _private_string;``).
-    * Choose lowercase, preferrably short namespace names (i.e. ``namespace plugins { ... }``).
+    * Choose lowercase, preferably short namespace names (i.e. ``namespace plugins { ... }``).
 * Code structure
     * All your code should reside in a meaningful namespace.
     * Declare class and functions in header (".h") files.

--- a/docs/initial-configuration.rst
+++ b/docs/initial-configuration.rst
@@ -11,13 +11,13 @@ When you use this plugin for the first time, you're likely to encounter the foll
 
     [*] Warning: The VirusTotal API key was not found in the configuration file.
 	
-In order to submit hashes to VirusTotal, it is necessary to `register <https://www.virustotal.com/en/>`_ on their website and retreive an API key. If you really can't be bothered, many of these can be found on `GitHub <https://github.com/search?q=%22https%3A%2F%2Fwww.virustotal.com%2Fvtapi%2Fv2%22&type=Code&utf8=%E2%9C%93>`_.
+In order to submit hashes to VirusTotal, it is necessary to `register <https://www.virustotal.com/en/>`_ on their website and retrieve an API key. If you really can't be bothered, many of these can be found on `GitHub <https://github.com/search?q=%22https%3A%2F%2Fwww.virustotal.com%2Fvtapi%2Fv2%22&type=Code&utf8=%E2%9C%93>`_.
 
 VirusTotal offers two types of API access: public and private. Right now, Manalyze doesn't support any of the "private" features, but if you're lucky enough to have a such a key, at least you won't be bound by the request rate limit. After you have obtained an API key, edit ``bin/manalyze.conf`` and add the following line::
 
     virustotal.api_key = [your key here]
 	
-After this, the plugin will be able to retreive hashes from VirusTotal.
+After this, the plugin will be able to retrieve hashes from VirusTotal.
 
 ClamAV plugin
 =============

--- a/docs/writing-plugins.rst
+++ b/docs/writing-plugins.rst
@@ -108,7 +108,7 @@ If you try to build the plugin right now, you'll see that the compiler is very a
 These functions serve the following purpose:
 
 * ``get_api_version``: the version of the API used by this plugin, in case it evolves and breaks retro-compatibility in the future. Just return 1 for now.
-* ``get_id``: the name of the plugin. This is how it will be refered to in the program's help and on the command-line; make sure to pick something unique!
+* ``get_id``: the name of the plugin. This is how it will be referred to in the program's help and on the command-line; make sure to pick something unique!
 * ``get_description``: a short explanation of what the plugin does. It is only printed when the user calls Manalyze with the ``--help`` option.
 * ``analyze``: performs the analysis of the program. We'll get back to this one very soon, for now, it just creates a result object containing a message.
 

--- a/manape/pe.cpp
+++ b/manape/pe.cpp
@@ -844,7 +844,7 @@ bool PE::_parse_tls()
  *	@param	read_bytes	The number of bytes read so far, will be incremented.
  *	
  *	@return	Whether the value should be read. If false, EOF has been reached or
- *			the stucture has no more fields to read.
+ *			the structure has no more fields to read.
  */
 bool read_config_field(const			image_load_config_directory& config,
 					   FILE*			source,

--- a/plugins/plugin_authenticode/asn1.h
+++ b/plugins/plugin_authenticode/asn1.h
@@ -111,7 +111,7 @@ long asn1_read(const unsigned char** data,
  *
  *  The SpcIndirectDataContent contains the digest and algorithm of the authenticode
  *  hash generated for the PE. This function's role is to go down the ASN1 rabbit hole
- *  and retreive this information so that the digest can be computed independently and
+ *  and retrieve this information so that the digest can be computed independently and
  *  verified against the information contained in this signature.
  *
  *  @param  ASN1_STRING* asn1 The ASN1 string pointing to the SpcIndirectDataContent object.

--- a/plugins/plugin_authenticode/plugin_authenticode_openssl.cpp
+++ b/plugins/plugin_authenticode/plugin_authenticode_openssl.cpp
@@ -116,7 +116,7 @@ std::string hexlify(const bytes& buffer)
 
 /**
  *  @brief  This function navigates through the digital signature's
- *          certificate chain to retreive the successive common names.
+ *          certificate chain to retrieve the successive common names.
  *
  *  @param  pPKCS7 p The PKCS7 object containing the digital signature.
  *  @param  pResult res The result in which the names should be added.

--- a/plugins/plugin_virustotal/plugin_virustotal.cpp
+++ b/plugins/plugin_virustotal/plugin_virustotal.cpp
@@ -53,7 +53,7 @@ namespace plugin {
  *
  *	@param	const std::string& hash The hash of the program whose AV results we want.
  *	@param	const std::string& api_key The VirusTotal API key used to submit queries.
- *	@param	std::string& destination The string which will recieve the REST JSON response.
+ *	@param	std::string& destination The string which will receive the REST JSON response.
  *
  *	@return	Whether the query was completed successfully.
  */
@@ -191,7 +191,7 @@ public:
  *
  *	@param	const std::string& hash The hash of the program whose AV results we want.
  *	@param	const std::string& api_key The VirusTotal API key used to submit queries.
- *	@param	std::string& destination The string which will recieve the REST JSON response.
+ *	@param	std::string& destination The string which will receive the REST JSON response.
  *	@param	sslsocket& socket or bai::tcp::socket& socket The socket connected to the API.
  *			Its type will vary depending on whether OpenSSL is available (in which case,
  *			the socket will automatically be an SSL socket).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -282,7 +282,7 @@ bool parse_args(po::variables_map& vm, int argc, char**argv)
 /**
  *	@brief	Dumps select information from a PE.
  *
- *	@param	io::OutputFormatter& formatter The object which will recieve the output.
+ *	@param	io::OutputFormatter& formatter The object which will receive the output.
  *	@param	const std::vector<std::string>& categories The types of information to dump.
  *			For the list of accepted categories, refer to the program help or the source
  *			below.
@@ -342,7 +342,7 @@ void handle_dump_option(io::OutputFormatter& formatter, const std::vector<std::s
 /**
  *	@brief	Analyze the PE with each selected plugin.
  *
- *	@param	io::OutputFormatter& formatter The object which will recieve the output.
+ *	@param	io::OutputFormatter& formatter The object which will receive the output.
  *	@param	const std::vector<std::string>& selected The names of the selected plugins.
  *	@param	const config& conf The configuration of the plugins.
  *	@param	const mana::PE& pe The PE to analyze.


### PR DESCRIPTION
Hello.

It's been a while.

I corrected the typos.

Thanks.

Changes:
```
/plugins/plugin_authenticode/asn1.h:114: retreive -> "retrieve"
/plugins/plugin_authenticode/plugin_authenticode_openssl.cpp:119: retreive -> "retrieve"
/plugins/plugin_virustotal/plugin_virustotal.cpp:56: recieve -> "receive"
/plugins/plugin_virustotal/plugin_virustotal.cpp:194: recieve -> "receive"
/src/main.cpp:285: recieve -> "receive"
/src/main.cpp:345: recieve -> "receive"
/manape/pe.cpp:847: stucture -> "structure"
/docs/writing-plugins.rst:111: refered -> "referred"
/docs/initial-configuration.rst:14: retreive -> "retrieve"
/docs/initial-configuration.rst:20: retreive -> "retrieve"
/docs/before-contributing.rst:43: preferrably -> "preferably"
```