### PR TITLE
Document make install on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ $> make -j5
 $> cd bin && ./manalyze --version
 ```
 
+Finally, if you want to access Manalyze from every directory on your machine, install it using `$> make install` from the root folder of the project.
+
 ### On Windows
 - Get the Boost libraries from [boost.org](http://boost.org) and install [CMake](http://www.cmake.org/download/).
 - Build the boost libraries
@@ -59,6 +61,7 @@ user$ brew install openssl boost
 user$ cmake . -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/ && make -j5
 user$ bin && ./manalyze --version
 ```
+Finally, if you want to access Manalyze from every directory on your machine, install it using `$> make install` from the root folder of the project.
 
 ### Offline builds
 If you need to build Manalyze on a machine with no internet access, you have to manually check out the following projects:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ user$ brew install openssl boost
 user$ cmake . -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/ && make -j5
 user$ bin && ./manalyze --version
 ```
-Finally, if you want to access Manalyze from every directory on your machine, install it using `$> make install` from the root folder of the project.
 
 ### Offline builds
 If you need to build Manalyze on a machine with no internet access, you have to manually check out the following projects:


### PR DESCRIPTION
This small pull request documents the existence of `make install` for users who wish to easily access Manalyze from everywhere on their machine.

While I am personally not a big fan of `make install`, some would find it useful.