### PR TITLE
update_clamav_signatures.py: do not process comments

### DIFF
--- a/bin/yara_rules/parse_clamav.py
+++ b/bin/yara_rules/parse_clamav.py
@@ -317,6 +317,8 @@ def parse_ldb(input, output, is_daily=False):
     with open(input) as f:
         with open(output, 'ab') as g:
             for line in f:
+                if line.lstrip().startswith('#'):
+                    continue
                 data = line.rstrip("\n").split(";")
                 malware_name = data[0]
                 target_block = dict()


### PR DESCRIPTION
the program fails if a line starting with '#' is found in .ldb files:

```
root@3450da1b008d:/Manalyze# bin/yara_rules/update_clamav_signatures.py
Downloading: main.cvd Bytes: 168205379
Rule Win.Trojan.EOL-1 seems to be malformed. Skipping...
Traceback (most recent call last):
  File "/Manalyze/bin/yara_rules/update_clamav_signatures.py", line 166, in <module>
    update_signatures(URL_MAIN, args.skipdownload)
  File "/Manalyze/bin/yara_rules/update_clamav_signatures.py", line 138, in update_signatures
    parse_ldb("%s.ldb" % file_basename, "clamav.yara", file_basename != "main")
  File "/Manalyze/bin/yara_rules/parse_clamav.py", line 323, in parse_ldb
    for block in data[1].split(","):
IndexError: list index out of range
```