### PR TITLE
Fixed superfluous flush when hitting last target in loop (#63 edge case)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -562,10 +562,11 @@ int main(int argc, char** argv)
 
 	// Do the actual analysis on all the input files
 	unsigned int count = 0;
+	unsigned int tsize = targets.size();
 	for (const auto& it : targets)
 	{
 		perform_analysis(it, opts, extraction_directory, selected_categories, selected_plugins, conf, formatter);
-		if (++count % 1000 == 0) {
+		if (++count % 1000 == 0 && count < tsize) {
 			formatter->format(std::cout, false); // Flush the formatter from time to time, to avoid eating up all the RAM when analyzing gigs of files.
 		}
 	}


### PR DESCRIPTION
This is an edge case fix related to #63.

## Issue

When performing recursive scan on the exact same amount of targets than the flush modulo *(here 1000)*, flush gets triggered two times in a row, omitting the real state of `end_stream` boolean *(`true`)*.

## Observed result

Program leaves a superfluous comma in JSON output for modulo 1000 target amount.